### PR TITLE
[FIX] Update Dockerfile with last Odoo 8.0 version

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -9,25 +9,48 @@ RUN set -x; \
             curl \
             node-less \
             node-clean-css \
+            python-gevent \
+            python-pip \
             python-pyinotify \
             python-renderpm \
             python-support \
+            unzip \
         && curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
-        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb \
+        && pip install psycogreen==1.0
+
+# install latest postgresql-client
+RUN set -x; \
+        echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > etc/apt/sources.list.d/pgdg.list \
+        && export GNUPGHOME="$(mktemp -d)" \
+        && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+        && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+        && gpg --armor --export "${repokey}" | apt-key add - \
+        && rm -rf "$GNUPGHOME" \
+        && apt-get update  \
+        && apt-get install -y postgresql-client \
+        && rm -rf /var/lib/apt/lists/*
 
 # Install Odoo
 ENV ODOO_VERSION 8.0
-ENV ODOO_RELEASE 20160405
+ENV ODOO_RELEASE 20170815
 RUN set -x; \
         curl -o odoo.deb -SL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+        && echo '5835e966a07e5684b4f7bcc39585276b0bb68254 odoo.deb' | sha1sum -c - \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \
         && apt-get -y install -f --no-install-recommends \
         && rm -rf /var/lib/apt/lists/* odoo.deb
+
+# Install barcode font
+RUN set -x; \
+        curl -o pfbfer.zip -SL http://www.reportlab.com/ftp/pfbfer.zip \
+        && mkdir -p /usr/lib/python2.7/dist-packages/reportlab/fonts \
+        && unzip pfbfer.zip -d /usr/lib/python2.7/dist-packages/reportlab/fonts/
 
 # Copy entrypoint script and Odoo configuration file
 COPY ./entrypoint.sh /
@@ -45,7 +68,6 @@ EXPOSE 8069 8071
 # Set the default config file
 ENV OPENERP_SERVER /etc/odoo/openerp-server.conf
 
-# Set default user when running the container
 USER odoo
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
With the recent Debian sources change the builds were failing. When trying to rebuild, the Odoo source that was referenced in the file was also failing. This adds the last know working nightly of Odoo 8.0.